### PR TITLE
fix php5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "^5.1"
+        "illuminate/support": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
illuminate/support 5.1 is only compatible with php7 because of using the "coalescing operator" (??)