### PR TITLE
Handle invalid file path in XML\Reader::load() by throwing a relevent exception

### DIFF
--- a/src/FileNotFoundException.php
+++ b/src/FileNotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravie\Parser;
+
+class FileNotFoundException extends \InvalidArgumentException
+{
+    //
+}

--- a/src/Xml/Reader.php
+++ b/src/Xml/Reader.php
@@ -4,6 +4,7 @@ namespace Laravie\Parser\Xml;
 
 use Laravie\Parser\Reader as BaseReader;
 use Laravie\Parser\InvalidContentException;
+use Laravie\Parser\FileNotFoundException;
 use Laravie\Parser\Document as BaseDocument;
 
 class Reader extends BaseReader
@@ -23,6 +24,10 @@ class Reader extends BaseReader
      */
     public function load(string $filename): BaseDocument
     {
+        if (!file_exists($filename)) {
+            throw new FileNotFoundException('Could not find the file: ' . $filename);
+        }
+
         $xml = @simplexml_load_file($filename);
 
         return $this->resolveXmlObject($xml);

--- a/tests/Xml/ReaderTest.php
+++ b/tests/Xml/ReaderTest.php
@@ -39,6 +39,30 @@ class ReaderTest extends TestCase
     }
 
     /**
+     * Test Laravie\Parser\Xml\Reader::load() method.
+     *
+     * @expectedException \Laravie\Parser\FileNotFoundException
+     */
+    public function testLoadMethodThrowsFileNotFoundException()
+    {
+        $document = new Document();
+        $stub = new Reader($document);
+        $output = $stub->load('');
+    }
+
+    /**
+     * Test Laravie\Parser\Xml\Reader::load() method.
+     *
+     * @expectedException \Laravie\Parser\InvalidContentException
+     */
+    public function testLoadMethodThrowsInvalidContentExceptionException()
+    {
+        $document = new Document();
+        $stub = new Reader($document);
+        $output = $stub->load(__DIR__.'/stubs/invalid.xml');
+    }
+
+    /**
      * Test Laravie\Parser\Xml\Reader::extract() method throws exception.
      *
      * @expectedException \Laravie\Parser\InvalidContentException

--- a/tests/Xml/stubs/invalid.xml
+++ b/tests/Xml/stubs/invalid.xml
@@ -1,0 +1,4 @@
+<!-- This is an invalid xml -->
+<a>
+    <foo>foobar</foo>
+</b>


### PR DESCRIPTION
## Description
I added a `FileNotFoundException.php` containing a class similar to `Laravie\Parser\Xml\InvalidContentException`.  It is thrown when `Xml\Reader::load($filename)` is called with a file that don't exists.

It fixes #9 : Misleading error when file does not exists.

## Tests
1. A test case has been added to `ReaderTest.php`  to make sure that the exception is thrown when the file does not exists.

2. In addition to that, I allowed myself to add a test case for `InvalidContentException` because it was missing and my changes could have impact that behavior.