### PR TITLE
Revert "Handle invalid file path in XML\Reader::load() by throwing a relevent exception" as it breaks remote url parsing

### DIFF
--- a/src/FileNotFoundException.php
+++ b/src/FileNotFoundException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Laravie\Parser;
-
-class FileNotFoundException extends \InvalidArgumentException
-{
-    //
-}

--- a/src/Xml/Reader.php
+++ b/src/Xml/Reader.php
@@ -3,7 +3,6 @@
 namespace Laravie\Parser\Xml;
 
 use Laravie\Parser\Reader as BaseReader;
-use Laravie\Parser\FileNotFoundException;
 use Laravie\Parser\InvalidContentException;
 
 class Reader extends BaseReader
@@ -23,10 +22,6 @@ class Reader extends BaseReader
      */
     public function load($filename)
     {
-        if (!file_exists($filename)) {
-            throw new FileNotFoundException('Could not find the file: ' . $filename);
-        }
-
         $xml = @simplexml_load_file($filename);
 
         return $this->resolveXmlObject($xml);

--- a/tests/Xml/ReaderTest.php
+++ b/tests/Xml/ReaderTest.php
@@ -39,30 +39,6 @@ class ReaderTest extends TestCase
     }
 
     /**
-     * Test Laravie\Parser\Xml\Reader::load() method.
-     *
-     * @expectedException \Laravie\Parser\FileNotFoundException
-     */
-    public function testLoadMethodThrowsFileNotFoundException()
-    {
-        $document = new Document();
-        $stub = new Reader($document);
-        $output = $stub->load('');
-    }
-
-    /**
-     * Test Laravie\Parser\Xml\Reader::load() method.
-     *
-     * @expectedException \Laravie\Parser\InvalidContentException
-     */
-    public function testLoadMethodThrowsInvalidContentExceptionException()
-    {
-        $document = new Document();
-        $stub = new Reader($document);
-        $output = $stub->load(__DIR__.'/stubs/invalid.xml');
-    }
-
-    /**
      * Test Laravie\Parser\Xml\Reader::extract() method throws exception.
      *
      * @expectedException \Laravie\Parser\InvalidContentException

--- a/tests/Xml/stubs/invalid.xml
+++ b/tests/Xml/stubs/invalid.xml
@@ -1,4 +1,0 @@
-<!-- This is an invalid xml -->
-<a>
-    <foo>foobar</foo>
-</b>


### PR DESCRIPTION
This reverts commits
e9fdbc1db63b9871b6dc6a51bb425e838536d5b6
a0835cc80ceadfc748b0fdbde31c3a52e5648ac8