### PR TITLE
Update readme.md: Use <?php tag to correct php syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Imagine if you can parse
 to
 
 ```php
+<?php
+
 $user = [
     'id' => '1',
     'email' => 'crynobone@gmail.com',
@@ -35,6 +37,8 @@ $user = [
 by just writing this:
 
 ```php
+<?php
+
 use Laravie\Parser\Xml\Reader;
 use Laravie\Parser\Xml\Document;
 


### PR DESCRIPTION
When you want to show php code in your markdown file you will need to use the ```php and the <?php tag to use the syntax highlighting.