### PR TITLE
php 8.1 compatibility fix

### DIFF
--- a/src/Xml/Definitions/MultiLevel.php
+++ b/src/Xml/Definitions/MultiLevel.php
@@ -67,7 +67,7 @@ class MultiLevel implements IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->uses);
     }


### PR DESCRIPTION
Without this fix: 

```
Deprecated
Return type of Laravie\Parser\Xml\Definitions\MultiLevel::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

Please accept this and release the new version. Thank you!