### PR TITLE
Fix for multi-level xml tags (lvl 3+)

### DIFF
--- a/src/Xml/Concerns/SupportMultiLevel.php
+++ b/src/Xml/Concerns/SupportMultiLevel.php
@@ -110,6 +110,10 @@ trait SupportMultiLevel
                         $uses[$current] = '';
                         --$level;
                         break;
+                    } else {
+                        $uses[$current] .= '}';
+                        --$level;
+                        break;
                     }
                     // no break
                 default:

--- a/tests/Xml/DocumentTest.php
+++ b/tests/Xml/DocumentTest.php
@@ -720,13 +720,17 @@ class DocumentTest extends TestCase
                     'DynPar' => 'T0019:1,R0109:,R0108:,R0107:,T0025:X',
                     'StatusItem' => 'REJECTED',
                     'Error' => [
-                        'Code' => 'ERR_2059',
-                        'Severity' => 'Critical',
-                        'Text' => 'Error message ERR_2059.',
-                        'Localization' => [
-                            'DataAreaCode' => 'AREA1_CODE',
-                            'Detail' =>[
-                                'DynPar' => 'T0019:1,R0109:test1,R0108:,R0107:,T0025:X'
+                        [
+                            'Code' => 'ERR_2059',
+                            'Severity' => 'Critical',
+                            'Text' => 'Error message ERR_2059.',
+                            'Localization' => [
+                                [
+                                    'DataAreaCode' => 'AREA1_CODE',
+                                    'Detail' =>[
+                                        'DynPar' => 'T0019:1,R0109:test1,R0108:,R0107:,T0025:X'
+                                    ]
+                               ]
                             ]
                         ]
                     ]
@@ -735,13 +739,17 @@ class DocumentTest extends TestCase
                     'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
                     'StatusItem' => 'REJECTED',
                     'Error' => [
-                        'Code' => 'ERR_2060',
-                        'Severity' => 'Warning',
-                        'Text' => 'Error message ERR_2060.',
-                        'Localization' => [
-                            'DataAreaCode' => 'AREA2_CODE',
-                            'Detail' => [
-                                'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X'
+                        [
+                            'Code' => 'ERR_2060',
+                            'Severity' => 'Warning',
+                            'Text' => 'Error message ERR_2060.',
+                            'Localization' => [
+                                [
+                                    'DataAreaCode' => 'AREA2_CODE',
+                                    'Detail' => [
+                                        'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X'
+                                    ]
+                                ]
                             ]
                         ]
                     ]

--- a/tests/Xml/DocumentTest.php
+++ b/tests/Xml/DocumentTest.php
@@ -762,6 +762,47 @@ class DocumentTest extends TestCase
             ],
         ];
 	    
+        $stub = new DocumentStub();
+
+        $stub->setContent(simplexml_load_string("<StepProcess>
+		<StepName>FORMAT_CONTROL</StepName>
+		<Result>NOT_ACCEPTED</Result>
+		<ErrorsProcess>
+			<ErrorItem>
+				<DataArea>AREA1</DataArea>
+				<DynPar>T0019:1,R0109:,R0108:,R0107:,T0025:X</DynPar>
+				<StatusItem>REJECTED</StatusItem>
+				<Error>
+					<Code>ERR_2059</Code>
+					<Severity>Critical</Severity>
+					<Text>Error message ERR_2059.</Text>
+					<Localization>
+						<DataAreaCode>AREA1_CODE</DataAreaCode>
+						<Detail>
+							<DynPar>T0019:1,R0109:test1,R0108:,R0107:,T0025:X</DynPar>
+						</Detail>
+					</Localization>
+				</Error>
+			</ErrorItem>
+			<ErrorItem>
+				<DataArea>AREA2</DataArea>
+				<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
+				<StatusItem>REJECTED</StatusItem>
+				<Error>
+					<Code>ERR_2060</Code>
+					<Severity>Warning</Severity>
+					<Text>Error message ERR_2060.</Text>
+					<Localization>
+						<DataAreaCode>AREA2_CODE</DataAreaCode>
+						<Detail>
+							<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
+						</Detail>
+					</Localization>
+				</Error>
+			</ErrorItem>
+		</ErrorsProcess>
+	</StepProcess>"));
+	    
         $data = $stub->parse([
             'errors' => ['uses' => 'ErrorsProcess[ErrorItem{DataArea,DynPar,StatusItem,Error{Code,Severity,Text,Localization{DataAreaCode,Detail.DynPar}}}]'],
         ]);

--- a/tests/Xml/DocumentTest.php
+++ b/tests/Xml/DocumentTest.php
@@ -713,91 +713,55 @@ class DocumentTest extends TestCase
      /** @test */
     public function testParseValueCollectionMultiLevelsPartTwo()
     {
-        $expected = [
+	$expected = [
             'errors' => [
-                'ErrorItem' => [
-                    'DataArea' => 'AREA1',
-                    'DynPar' => 'T0019:1,R0109:,R0108:,R0107:,T0025:X',
-                    'StatusItem' => 'REJECTED',
-                    'Error' => [
+                [
+                    'ErrorItem' => [
                         [
-                            'Code' => 'ERR_2059',
-                            'Severity' => 'Critical',
-                            'Text' => 'Error message ERR_2059.',
-                            'Localization' => [
+                            'DataArea'   => 'AREA1',
+                            'DynPar'     => 'T0019:1,R0109:,R0108:,R0107:,T0025:X',
+                            'StatusItem' => 'REJECTED',
+                            'Error'      => [
                                 [
-                                    'DataAreaCode' => 'AREA1_CODE',
-                                    'Detail' =>[
-                                        'DynPar' => 'T0019:1,R0109:test1,R0108:,R0107:,T0025:X'
-                                    ]
-                               ]
-                            ]
-                        ]
-                    ]
-                ],[
-                    'DataArea' => 'AREA2',
-                    'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
-                    'StatusItem' => 'REJECTED',
-                    'Error' => [
+                                    'Code'         => 'ERR_2059',
+                                    'Severity'     => 'Critical',
+                                    'Text'         => 'Error message ERR_2059.',
+                                    'Localization' => [
+                                        [
+                                            'DataAreaCode' => 'AREA1_CODE',
+                                            'Detail'       => [
+                                                'DynPar' => 'T0019:1,R0109:test1,R0108:,R0107:,T0025:X',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
                         [
-                            'Code' => 'ERR_2060',
-                            'Severity' => 'Warning',
-                            'Text' => 'Error message ERR_2060.',
-                            'Localization' => [
+                            'DataArea'   => 'AREA2',
+                            'DynPar'     => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
+                            'StatusItem' => 'REJECTED',
+                            'Error'      => [
                                 [
-                                    'DataAreaCode' => 'AREA2_CODE',
-                                    'Detail' => [
-                                        'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                                    'Code'         => 'ERR_2060',
+                                    'Severity'     => 'Warning',
+                                    'Text'         => 'Error message ERR_2060.',
+                                    'Localization' => [
+                                        [
+                                            'DataAreaCode' => 'AREA2_CODE',
+                                            'Detail'       => [
+                                                'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
-
-        $stub = new DocumentStub();
-
-        $stub->setContent(simplexml_load_string("<StepProcess>
-		<StepName>FORMAT_CONTROL</StepName>
-		<Result>NOT_ACCEPTED</Result>
-		<ErrorsProcess>
-			<ErrorItem>
-				<DataArea>AREA1</DataArea>
-				<DynPar>T0019:1,R0109:,R0108:,R0107:,T0025:X</DynPar>
-				<StatusItem>REJECTED</StatusItem>
-				<Error>
-					<Code>ERR_2059</Code>
-					<Severity>Critical</Severity>
-					<Text>Error message ERR_2059.</Text>
-					<Localization>
-						<DataAreaCode>AREA1_CODE</DataAreaCode>
-						<Detail>
-							<DynPar>T0019:1,R0109:test1,R0108:,R0107:,T0025:X</DynPar>
-						</Detail>
-					</Localization>
-				</Error>
-			</ErrorItem>
-			<ErrorItem>
-				<DataArea>AREA2</DataArea>
-				<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
-				<StatusItem>REJECTED</StatusItem>
-				<Error>
-					<Code>ERR_2060</Code>
-					<Severity>Warning</Severity>
-					<Text>Error message ERR_2060.</Text>
-					<Localization>
-						<DataAreaCode>AREA2_CODE</DataAreaCode>
-						<Detail>
-							<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
-						</Detail>
-					</Localization>
-				</Error>
-			</ErrorItem>
-		</ErrorsProcess>
-	</StepProcess>"));
-
+	    
         $data = $stub->parse([
             'errors' => ['uses' => 'ErrorsProcess[ErrorItem{DataArea,DynPar,StatusItem,Error{Code,Severity,Text,Localization{DataAreaCode,Detail.DynPar}}}]'],
         ]);

--- a/tests/Xml/DocumentTest.php
+++ b/tests/Xml/DocumentTest.php
@@ -709,6 +709,94 @@ class DocumentTest extends TestCase
 
         $this->assertEquals($expected, $data);
     }
+    
+     /** @test */
+    public function testParseValueCollectionMultiLevelsPartTwo()
+    {
+        $expected = [
+            'errors' => [
+                'ErrorItem' => [
+                    'DataArea' => 'AREA1',
+                    'DynPar' => 'T0019:1,R0109:,R0108:,R0107:,T0025:X',
+                    'StatusItem' => 'REJECTED',
+                    'Error' => [
+                        'Code' => 'ERR_2059',
+                        'Severity' => 'Critical',
+                        'Text' => 'Error message ERR_2059.',
+                        'Localization' => [
+                            'DataAreaCode' => 'AREA1_CODE',
+                            'Detail' =>[
+                                'DynPar' => 'T0019:1,R0109:test1,R0108:,R0107:,T0025:X'
+                            ]
+                        ]
+                    ]
+                ],[
+                    'DataArea' => 'AREA2',
+                    'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
+                    'StatusItem' => 'REJECTED',
+                    'Error' => [
+                        'Code' => 'ERR_2060',
+                        'Severity' => 'Warning',
+                        'Text' => 'Error message ERR_2060.',
+                        'Localization' => [
+                            'DataAreaCode' => 'AREA2_CODE',
+                            'Detail' => [
+                                'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $stub = new DocumentStub();
+
+        $stub->setContent(simplexml_load_string("<StepProcess>
+		<StepName>FORMAT_CONTROL</StepName>
+		<Result>NOT_ACCEPTED</Result>
+		<ErrorsProcess>
+			<ErrorItem>
+				<DataArea>AREA1</DataArea>
+				<DynPar>T0019:1,R0109:,R0108:,R0107:,T0025:X</DynPar>
+				<StatusItem>REJECTED</StatusItem>
+				<Error>
+					<Code>ERR_2059</Code>
+					<Severity>Critical</Severity>
+					<Text>Error message ERR_2059.</Text>
+					<Localization>
+						<DataAreaCode>AREA1_CODE</DataAreaCode>
+						<Detail>
+							<DynPar>T0019:1,R0109:test1,R0108:,R0107:,T0025:X</DynPar>
+						</Detail>
+					</Localization>
+				</Error>
+			</ErrorItem>
+			<ErrorItem>
+				<DataArea>AREA2</DataArea>
+				<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
+				<StatusItem>REJECTED</StatusItem>
+				<Error>
+					<Code>ERR_2060</Code>
+					<Severity>Warning</Severity>
+					<Text>Error message ERR_2060.</Text>
+					<Localization>
+						<DataAreaCode>AREA2_CODE</DataAreaCode>
+						<Detail>
+							<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
+						</Detail>
+					</Localization>
+				</Error>
+			</ErrorItem>
+		</ErrorsProcess>
+	</StepProcess>
+<StepProcess>"));
+
+        $data = $stub->parse([
+            'errors' => ['uses' => 'ErrorsProcess[ErrorItem{DataArea,DynPar,StatusItem,Error{Code,Severity,Text,Localization{DataAreaCode,Detail.DynPar}}}]'],
+        ]);
+
+        $this->assertEquals($expected, $data);
+    }
 }
 
 class DocumentStub extends \Laravie\Parser\Xml\Document

--- a/tests/Xml/DocumentTest.php
+++ b/tests/Xml/DocumentTest.php
@@ -788,8 +788,7 @@ class DocumentTest extends TestCase
 				</Error>
 			</ErrorItem>
 		</ErrorsProcess>
-	</StepProcess>
-<StepProcess>"));
+	</StepProcess>"));
 
         $data = $stub->parse([
             'errors' => ['uses' => 'ErrorsProcess[ErrorItem{DataArea,DynPar,StatusItem,Error{Code,Severity,Text,Localization{DataAreaCode,Detail.DynPar}}}]'],


### PR DESCRIPTION
EXAMPLE XML:
```
<StepProcess>
		<StepName>FKZ</StepName>
		<Result>NEAKCEPTOVANO</Result>
		<ErrorsProcess>
			<ErrorItem>
				<DataArea>PERF30_11</DataArea>
				<DynPar>T0019:1,R0109:315700MJRNJSVB95U852,R0106:K#U\FB*Hr.`022Fi_Z::CzvCa,R0108:,R0107:,T0025:X</DynPar>
				<StatusItem>ODMITNUTO</StatusItem>
				<Error>
					<Code>SDAT_2059</Code>
					<Severity>Zavazna</Severity>
					<Text>Je-li záznam zaslán s parametrem T0025=X, musí existovat platný záznam se stejným číselníkovým klíčem.</Text>
					<Localization>
						<DataAreaCode>PERF30_11</DataAreaCode>
						<Detail>
							<DynPar>T0019:1,R0109:315700MJRNJSVB95U852,R0106:K#U\FB*Hr.`022Fi_Z::CzvCa,R0108:,R0107:,T0025:X</DynPar>
						</Detail>
					</Localization>
				</Error>
			</ErrorItem>
			<ErrorItem>
				<DataArea>PERF30_11</DataArea>
				<DynPar>T0019:2,R0109:IYKCAVNFR8QGF00HV840,R0106:Q-QY?6W'G?t(X!Q6kG)%h58uo'dW,R0108:,R0107:,T0025:X</DynPar>
				<StatusItem>ODMITNUTO</StatusItem>
				<Error>
					<Code>SDAT_2059</Code>
					<Severity>Zavazna</Severity>
					<Text>Je-li záznam zaslán s parametrem T0025=X, musí existovat platný záznam se stejným číselníkovým klíčem.</Text>
					<Localization>
						<DataAreaCode>PERF30_11</DataAreaCode>
						<Detail>
							<DynPar>T0019:2,R0109:IYKCAVNFR8QGF00HV840,R0106:Q-QY?6W'G?t(X!Q6kG)%h58uo'dW,R0108:,R0107:,T0025:X</DynPar>
						</Detail>
					</Localization>
				</Error>
			</ErrorItem>
		</ErrorsProcess>
	</StepProcess>
<StepProcess>
```


**Without this fix:**
**Case 1:**
- parseString: `'ProcessErrors[ErrorItem{DataArea,DynPar,StatusItem,Error{Code,Severity,Text}}]` 
- result: Working, everything is parsed to array

**Case 2:**
- parseString: `'ProcessErrors[ErrorItem{DataArea,DynPar,StatusItem,Error{Code,Severity,Text,Localization{DataAreaCode,Detail.DynPar}}}]` 

- result: NOT ok, whole part Error skipped

```
'errors_trn' => array (1)
   |  0 => array (1)
   |  |  'Error{Code,Severity,Text,Localization{DataAreaCode,Detail.DynPar}}}' => array (2)
   |  |  |  0 => array (3)
   |  |  |  |  'DataArea' => 'PERF30_11'
   |  |  |  |  'DynPar' => 'T0019:1,R0109:315700MJRNJSVB95U852,R0106:K#U\FB*Hr.`022Fi_Z::CzvCa,R0108:,R0107:,T0025:X'
   |  |  |  |  'StatusItem' => 'ODMITNUTO'
   |  |  |  1 => array (3)
   |  |  |  |  'DataArea' => 'PERF30_11'
   |  |  |  |  'DynPar' => 'T0019:2,R0109:IYKCAVNFR8QGF00HV840,R0106:Q-QY?6W'G?t(X!Q6kG)%h58uo'dW,R0108:,R0107:,T0025:X'
   |  |  |  |  'StatusItem' => 'ODMITNUTO'
```

With this fix, case 2 is now working