### PR TITLE
castValue will return array of values when last tag has several occurrences

### DIFF
--- a/src/Xml/Document.php
+++ b/src/Xml/Document.php
@@ -73,7 +73,7 @@ class Document extends BaseDocument
     }
 
     /**
-     * Cast value to string only when it is an instance of SimpleXMLElement.
+     * Cast value to string|array only when it is an instance of SimpleXMLElement.
      *
      * @param  mixed  $value
      *
@@ -82,7 +82,11 @@ class Document extends BaseDocument
     protected function castValue($value)
     {
         if ($value instanceof SimpleXMLElement) {
-            $value = (string) $value;
+            if ($value->count() > 1) {
+                $value = (array) $value;
+            } else {
+                $value = (string) $value;
+            }
         }
 
         return $value;

--- a/tests/Xml/DocumentTest.php
+++ b/tests/Xml/DocumentTest.php
@@ -750,7 +750,10 @@ class DocumentTest extends TestCase
                                         [
                                             'DataAreaCode' => 'AREA2_CODE',
                                             'Detail'       => [
-                                                'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
+                                                'DynPar' => [
+                                                    'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
+                                                    'T0019:3,R0109:test3,R0108:,R0107:,T0025:Y',
+                                                ],
                                             ],
                                         ],
                                     ],
@@ -796,6 +799,7 @@ class DocumentTest extends TestCase
 						<DataAreaCode>AREA2_CODE</DataAreaCode>
 						<Detail>
 							<DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
+							<DynPar>T0019:3,R0109:test3,R0108:,R0107:,T0025:Y</DynPar>
 						</Detail>
 					</Localization>
 				</Error>


### PR DESCRIPTION
When last tag has multiple occurrences, now only the first one is returned as string:
```
......
    <Detail>
        <DynPar>T0019:2,R0109:test2,R0108:,R0107:,T0025:X</DynPar>
        <DynPar>T0019:3,R0109:test3,R0108:,R0107:,T0025:Y</DynPar>
    </Detail>
....
```
Current result is only value from first tag:
`'DynPar' => 'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',`

After this commit, it will return array of values:
```
'DynPar' => [
        'T0019:2,R0109:test2,R0108:,R0107:,T0025:X',
        'T0019:3,R0109:test3,R0108:,R0107:,T0025:Y',
    ],
```
